### PR TITLE
travis-ci: disabling homebrew auto-update

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 if [[ "$(uname -s)" == 'Darwin' ]]; then
-    brew install cmake || :
-    brew install python3 || :
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake || :
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install python3 || :
 fi
 pip3 install conan --upgrade


### PR DESCRIPTION
Disabling homebrew auto update with:
> `HOMEBREW_NO_AUTO_UPDATE=1`

Disabling auto-update as we don't really require it for our builds.
Also makes the jobs run twice as fast.