### PR TITLE
Travis ci: updating/optimizing

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-set -x
-if [[ "$(uname -s)" == 'Darwin' ]]; then
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install cmake || :
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install python3 || :
-fi
-pip3 install conan --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 
 install:
   - conan config install https://github.com/includeos/conan_config.git
+  - conan --version
 
 script:
   - conan create . includeos/latest -pr apple-clang-10-macos-toolchain

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ language: cpp
 compiler:
     - clang
 
+before_cache:
+  - brew cleanup
+
+cache:
+  - directories:
+    - $HOME/Library/Caches/Homebrew
+    
 install:
   - .ci/install.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 os: osx
 language: cpp
 
+addons:
+  homebrew:
+    packages:
+    - cmake
+    - python3
+    - conan
+
 compiler:
     - clang
 
@@ -10,12 +17,11 @@ before_cache:
 cache:
   - directories:
     - $HOME/Library/Caches/Homebrew
-    
+
 install:
-  - .ci/install.sh
+  - conan config install https://github.com/includeos/conan_config.git
 
 script:
-  - conan config install https://github.com/includeos/conan_config.git
   - conan create . includeos/latest -pr apple-clang-10-macos-toolchain
   - VERSION=$(conan inspect -a version . | cut -d " " -f 2)
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: osx
+osx_image: xcode10.2
 language: cpp
 
 addons:
@@ -9,7 +10,7 @@ addons:
     - conan
 
 compiler:
-    - clang
+  - clang
 
 before_cache:
   - brew cleanup


### PR DESCRIPTION
1. Travis will now use `macOS 10.14` instance.
2. Added homebrew cache
3. Travis will now use the homebrew addon to get brew and packages asked for
4. Removed shell scripts folder `.ci`